### PR TITLE
Rock-Paper-Scissor pallet implementation

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3899,6 +3899,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -4,7 +4,7 @@ use crate::{
 	service,
 };
 use node_rps_runtime::Block;
-use sc_cli::{ChainSpec, Role, RuntimeVersion, SubstrateCli};
+use sc_cli::{ChainSpec, RuntimeVersion, SubstrateCli};
 use sc_service::PartialComponents;
 
 impl SubstrateCli for Cli {
@@ -36,8 +36,9 @@ impl SubstrateCli for Cli {
 		Ok(match id {
 			"dev" => Box::new(chain_spec::development_config()?),
 			"" | "local" => Box::new(chain_spec::local_testnet_config()?),
-			path =>
-				Box::new(chain_spec::ChainSpec::from_json_file(std::path::PathBuf::from(path))?),
+			path => {
+				Box::new(chain_spec::ChainSpec::from_json_file(std::path::PathBuf::from(path))?)
+			},
 		})
 	}
 
@@ -98,7 +99,7 @@ pub fn run() -> sc_cli::Result<()> {
 				Ok((cmd.run(client, backend), task_manager))
 			})
 		},
-		Some(Subcommand::Benchmark(cmd)) =>
+		Some(Subcommand::Benchmark(cmd)) => {
 			if cfg!(feature = "runtime-benchmarks") {
 				let runner = cli.create_runner(cmd)?;
 
@@ -107,7 +108,8 @@ pub fn run() -> sc_cli::Result<()> {
 				Err("Benchmarking wasn't enabled when building the node. You can enable it with \
 				     `--features runtime-benchmarks`."
 					.into())
-			},
+			}
+		},
 		None => {
 			let runner = cli.create_runner(&cli.run)?;
 			runner.run_node_until_exit(|config| async move {

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -60,7 +60,7 @@ pub fn new_partial(
 	ServiceError,
 > {
 	if config.keystore_remote.is_some() {
-		return Err(ServiceError::Other("Remote Keystores are not supported.".into()))
+		return Err(ServiceError::Other("Remote Keystores are not supported.".into()));
 	}
 
 	let telemetry = config
@@ -173,11 +173,12 @@ pub fn new_full(mut config: Configuration) -> Result<TaskManager, ServiceError> 
 	if let Some(url) = &config.keystore_remote {
 		match remote_keystore(url) {
 			Ok(k) => keystore_container.set_remote_keystore(k),
-			Err(e) =>
+			Err(e) => {
 				return Err(ServiceError::Other(format!(
 					"Error hooking up remote keystore for {}: {}",
 					url, e
-				))),
+				)))
+			},
 		};
 	}
 	let grandpa_protocol_name = sc_finality_grandpa::protocol_standard_name(

--- a/pallets/rps/Cargo.toml
+++ b/pallets/rps/Cargo.toml
@@ -14,6 +14,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
+sp-std = { default-features = false, version = "4.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.17" }
+sp-io = { default-features = false, version = "5.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.17" }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 frame-support = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.17"}
 frame-system = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.17" }
@@ -28,6 +30,7 @@ sp-runtime = { default-features = false, version = "5.0.0", git = "https://githu
 default = ["std"]
 std = [
 	"codec/std",
+	"sp-io/std",
 	"scale-info/std",
 	"frame-support/std",
 	"frame-system/std",

--- a/pallets/rps/Cargo.toml
+++ b/pallets/rps/Cargo.toml
@@ -30,6 +30,7 @@ sp-runtime = { default-features = false, version = "5.0.0", git = "https://githu
 default = ["std"]
 std = [
 	"codec/std",
+	"sp-std/std",
 	"sp-io/std",
 	"scale-info/std",
 	"frame-support/std",

--- a/pallets/rps/src/lib.rs
+++ b/pallets/rps/src/lib.rs
@@ -1,8 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-/// Edit this file to define custom logic or remove it if it is not needed.
-/// Learn more about FRAME and the core library of Substrate FRAME pallets:
-/// <https://docs.substrate.io/v3/runtime/frame>
+use frame_support::pallet_prelude::*;
+
 pub use pallet::*;
 
 #[cfg(test)]
@@ -14,89 +13,427 @@ mod tests;
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
 
+pub type ChallengeId = u64;
+
+pub type ChallengePlayHash = [u8; 8];
+
+#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+pub struct OpenChallenge<AccountId: PartialEq + Clone, Balance> {
+	challenger: AccountId,
+	bet_amount: Balance,
+}
+
+#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+pub struct AcceptedChallenge<AccountId: PartialEq + Clone, Balance> {
+	challenger: AccountId,
+	rival: AccountId,
+	bet_amount: Balance,
+}
+
+impl<AccountId: PartialEq + Clone, Balance> AcceptedChallenge<AccountId, Balance> {
+	pub fn from_open(open_challenge: OpenChallenge<AccountId, Balance>, rival: AccountId) -> Self {
+		AcceptedChallenge {
+			challenger: open_challenge.challenger,
+			rival,
+			bet_amount: open_challenge.bet_amount,
+		}
+	}
+
+	pub fn contains_player(&self, player: &AccountId) -> bool {
+		self.challenger == *player || self.rival == *player
+	}
+
+	pub fn get_rival(&self, player: &AccountId) -> Option<AccountId> {
+		if self.challenger == *player {
+			Some(self.rival.clone())
+		} else if self.rival == *player {
+			Some(self.challenger.clone())
+		} else {
+			None
+		}
+	}
+}
+
+#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+pub struct FinishedChallenge<AccountId: PartialEq + Clone, Balance> {
+	challenger: AccountId,
+	rival: AccountId,
+	bet_amount: Balance,
+	winner: Option<AccountId>,
+}
+
+impl<AccountId: PartialEq + Clone, Balance> FinishedChallenge<AccountId, Balance> {
+	pub fn from_accepted(
+		accepted_challenge: AcceptedChallenge<AccountId, Balance>,
+		winner: Option<AccountId>,
+	) -> Self {
+		FinishedChallenge {
+			challenger: accepted_challenge.challenger,
+			rival: accepted_challenge.rival,
+			bet_amount: accepted_challenge.bet_amount,
+			winner,
+		}
+	}
+}
+
+#[derive(Clone, Encode, Decode, TypeInfo, MaxEncodedLen)]
+pub enum ChallengeState<AccountId: PartialEq + Clone, Balance> {
+	Open(OpenChallenge<AccountId, Balance>),
+	Accepted(AcceptedChallenge<AccountId, Balance>),
+	Finished(FinishedChallenge<AccountId, Balance>),
+}
+
+#[derive(Debug, Clone, PartialEq, Encode, Decode, TypeInfo, MaxEncodedLen)]
+pub enum ChallengePlay {
+	Rock,
+	Paper,
+	Scissors,
+}
+
+impl ChallengePlay {
+	fn as_bytes(&self) -> [u8; 1] {
+		match self {
+			ChallengePlay::Rock => 1_u8.to_ne_bytes(),
+			ChallengePlay::Paper => 2_u8.to_ne_bytes(),
+			ChallengePlay::Scissors => 3_u8.to_ne_bytes(),
+		}
+	}
+
+	pub fn generate_hash(&self, secret: u64) -> ChallengePlayHash {
+		let mut bytes = sp_std::vec::Vec::new();
+		bytes.extend(self.as_bytes());
+		bytes.extend(secret.to_ne_bytes());
+		sp_io::hashing::twox_64(&bytes)
+	}
+
+	pub fn compare_hash_with(&self, secret: u64, other_hash: ChallengePlayHash) -> bool {
+		self.generate_hash(secret) == other_hash
+	}
+}
+
+#[derive(Debug, Clone, PartialEq, Encode, Decode, TypeInfo, MaxEncodedLen)]
+pub enum PlayResult {
+	Win,
+	Lose,
+	Draw,
+}
+
+impl ChallengePlay {
+	pub fn beats(&self, other: &ChallengePlay) -> PlayResult {
+		match self {
+			ChallengePlay::Rock => match other {
+				ChallengePlay::Rock => PlayResult::Draw,
+				ChallengePlay::Paper => PlayResult::Lose,
+				ChallengePlay::Scissors => PlayResult::Win,
+			},
+			ChallengePlay::Paper => match other {
+				ChallengePlay::Rock => PlayResult::Win,
+				ChallengePlay::Paper => PlayResult::Draw,
+				ChallengePlay::Scissors => PlayResult::Lose,
+			},
+			ChallengePlay::Scissors => match other {
+				ChallengePlay::Rock => PlayResult::Lose,
+				ChallengePlay::Paper => PlayResult::Win,
+				ChallengePlay::Scissors => PlayResult::Draw,
+			},
+		}
+	}
+}
+
 #[frame_support::pallet]
 pub mod pallet {
-    use frame_support::pallet_prelude::*;
-    use frame_system::pallet_prelude::*;
+	use super::*;
+	use sp_std::ops::Mul;
 
-    /// Configure the pallet by specifying the parameters and types on which it depends.
-    #[pallet::config]
-    pub trait Config: frame_system::Config {
-        /// Because this pallet emits events, it depends on the runtime's definition of an event.
-        type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
-    }
+	use frame_support::traits::{BalanceStatus, Currency, ReservableCurrency};
+	use frame_system::pallet_prelude::*;
 
-    #[pallet::pallet]
-    #[pallet::generate_store(pub(super) trait Store)]
-    pub struct Pallet<T>(_);
+	type BalanceOf<T> =
+		<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 
-    // The pallet's runtime storage items.
-    // https://docs.substrate.io/v3/runtime/storage
-    #[pallet::storage]
-    #[pallet::getter(fn something)]
-    // Learn more about declaring storage items:
-    // https://docs.substrate.io/v3/runtime/storage#declaring-storage-items
-    pub type Something<T> = StorageValue<_, u32>;
+	/// Configure the pallet by specifying the parameters and types on which it depends.
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 
-    // Pallets use events to inform users when important changes are made.
-    // https://docs.substrate.io/v3/runtime/events-and-errors
-    #[pallet::event]
-    #[pallet::generate_deposit(pub(super) fn deposit_event)]
-    pub enum Event<T: Config> {
-        /// Event documentation should end with an array that provides descriptive names for event
-        /// parameters. [something, who]
-        SomethingStored(u32, T::AccountId),
-    }
+		type Currency: ReservableCurrency<Self::AccountId>;
 
-    // Errors inform users that something went wrong.
-    #[pallet::error]
-    pub enum Error<T> {
-        /// Error names should be descriptive.
-        NoneValue,
-        /// Errors should have helpful documentation associated with them.
-        StorageOverflow,
-    }
+		#[pallet::constant]
+		type MinBetAmount: Get<BalanceOf<Self>>;
+	}
 
-    // Dispatchable functions allows users to interact with the pallet and invoke state changes.
-    // These functions materialize as "extrinsics", which are often compared to transactions.
-    // Dispatchable functions must be annotated with a weight and must return a DispatchResult.
-    #[pallet::call]
-    impl<T: Config> Pallet<T> {
-        /// An example dispatchable that takes a singles value as a parameter, writes the value to
-        /// storage and emits an event. This function must be dispatched by a signed extrinsic.
-        #[pallet::weight(10_000 + T::DbWeight::get().writes(1))]
-        pub fn do_something(origin: OriginFor<T>, something: u32) -> DispatchResult {
-            // Check that the extrinsic was signed and get the signer.
-            // This function will return an error if the extrinsic is not signed.
-            // https://docs.substrate.io/v3/runtime/origins
-            let who = ensure_signed(origin)?;
+	#[pallet::pallet]
+	#[pallet::generate_store(pub (super) trait Store)]
+	pub struct Pallet<T>(_);
 
-            // Update storage.
-            <Something<T>>::put(something);
+	#[pallet::storage]
+	#[pallet::getter(fn next_challenge_id)]
+	pub type NextBetId<T> = StorageValue<_, ChallengeId, ValueQuery>;
 
-            // Emit an event.
-            Self::deposit_event(Event::SomethingStored(something, who));
-            // Return a successful DispatchResultWithPostInfo
-            Ok(())
-        }
+	#[pallet::storage]
+	#[pallet::getter(fn challenge_store)]
+	pub type ChallengeStore<T: Config> =
+		StorageMap<_, Blake2_128Concat, ChallengeId, ChallengeState<T::AccountId, BalanceOf<T>>>;
 
-        /// An example dispatchable that may throw a custom error.
-        #[pallet::weight(10_000 + T::DbWeight::get().reads_writes(1,1))]
-        pub fn cause_error(origin: OriginFor<T>) -> DispatchResult {
-            let _who = ensure_signed(origin)?;
+	#[pallet::storage]
+	#[pallet::getter(fn challenge_plays_store)]
+	pub type ChallengePlaysStore<T: Config> = StorageDoubleMap<
+		_,
+		Blake2_128Concat,
+		ChallengeId,
+		Blake2_128Concat,
+		T::AccountId,
+		ChallengePlayHash,
+	>;
 
-            // Read a value from storage.
-            match <Something<T>>::get() {
-                // Return an error if the value has not been set.
-                None => Err(Error::<T>::NoneValue)?,
-                Some(old) => {
-                    // Increment the value read from storage; will error in the event of overflow.
-                    let new = old.checked_add(1).ok_or(Error::<T>::StorageOverflow)?;
-                    // Update the value in storage with the incremented result.
-                    <Something<T>>::put(new);
-                    Ok(())
-                },
-            }
-        }
-    }
+	#[pallet::event]
+	#[pallet::generate_deposit(pub (super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// Triggered when a new challenge has been created. [challenge_id, creator_id, bet_amount]
+		ChallengeCreated(ChallengeId, T::AccountId, BalanceOf<T>),
+		/// Triggered when an account accepts a challenge. [challenge_id, challenger_id]
+		EnteredChallenge(ChallengeId, T::AccountId),
+		/// Triggered when an account plays in a certain challenge. [challenge_id, challenger_id]
+		PlayedInChallenge(ChallengeId, T::AccountId),
+		/// Triggered when both players have sent their play on a given challenge. [challenge_id]
+		ChallengeReadyForReveal(ChallengeId),
+		/// Triggered when a challenge has been finished. [winner_id]
+		ChallengeFinished(Option<T::AccountId>),
+	}
+
+	// Errors inform users that something went wrong.
+	#[pallet::error]
+	pub enum Error<T> {
+		/// The bet amount is not inferior to the minimum bet value
+		InsufficientBetAmount,
+		/// The challenge identifier could not be located
+		ChallengeNotFound,
+		/// The challenge is not open, so it cannot be entered
+		ChallengeNotOpen,
+		/// Cannot accept challenges created by the same account
+		CannotChallengeOneself,
+		/// Cannot play in a challenge in which the account is not a participant
+		CannotPlayInNonParticipatingChallenge,
+		/// Cannot play in a challenge not in the 'Accepted' state
+		ChallengeStateForbidsPlay,
+		/// Cannot play again in an already played challenge
+		ChallengeAlreadyPlayed,
+		/// Challenge state is not Accepted so it cannot be resolved
+		ChallengeStateForbidsResolution,
+		/// The challenge logic reached an invalid state
+		InvalidState,
+		/// Cannot reveal a challenge in which the account is not a participant
+		CannotRevealNonParticipatingChallenge,
+		/// The hash of the original account play and the value indicated in the reveal don't match
+		InvalidHandHash,
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		#[pallet::weight(10_000)]
+		pub fn create_challenge(origin: OriginFor<T>, bet_amount: BalanceOf<T>) -> DispatchResult {
+			let challenger = ensure_signed(origin)?;
+
+			let min_amount = T::MinBetAmount::get();
+			ensure!(bet_amount >= min_amount, Error::<T>::InsufficientBetAmount);
+
+			let challenge_id = NextBetId::<T>::get();
+			let challenge_state =
+				ChallengeState::Open(OpenChallenge { challenger: challenger.clone(), bet_amount });
+
+			NextBetId::<T>::mutate(|x| *x += 1);
+
+			ChallengeStore::<T>::insert(&challenge_id, challenge_state);
+
+			Self::deposit_event(Event::ChallengeCreated(challenge_id, challenger, bet_amount));
+
+			Ok(().into())
+		}
+
+		#[pallet::weight(10_000)]
+		pub fn enter_challenge(origin: OriginFor<T>, challenge_id: ChallengeId) -> DispatchResult {
+			let rival = ensure_signed(origin)?;
+
+			if let Err(e) = ChallengeStore::<T>::try_mutate(&challenge_id, |challenge_entry| {
+				ensure!(challenge_entry.is_some(), Error::<T>::ChallengeNotFound);
+
+				let challenge_state = challenge_entry.as_mut().unwrap();
+
+				if let ChallengeState::Open(open_state) = challenge_state {
+					if open_state.challenger == rival {
+						Err(Error::<T>::CannotChallengeOneself)
+					} else {
+						*challenge_state = ChallengeState::Accepted(AcceptedChallenge::from_open(
+							open_state.clone(),
+							rival.clone(),
+						));
+						Self::deposit_event(Event::EnteredChallenge(challenge_id, rival));
+						Ok(())
+					}
+				} else {
+					Err(Error::<T>::ChallengeNotOpen)
+				}
+			}) {
+				Err(e.into())
+			} else {
+				Ok(().into())
+			}
+		}
+
+		// play
+		// - Bet Id
+		// - Participant Id
+		// - Hand Payload (Encrypted<(HandType (Rock|Paper|Scissor))>, Public-Key)
+		#[pallet::weight(10_000)]
+		pub fn play_challenge(
+			origin: OriginFor<T>,
+			challenge_id: ChallengeId,
+			challenge_play: ChallengePlay,
+			challenger_secret: u64,
+		) -> DispatchResult {
+			let player = ensure_signed(origin)?;
+
+			if let Some(challenge) = ChallengeStore::<T>::get(&challenge_id) {
+				if let ChallengeState::Accepted(ref challenge_state) = challenge {
+					ensure!(
+						challenge_state.contains_player(&player),
+						Error::<T>::CannotPlayInNonParticipatingChallenge
+					);
+
+					ensure!(
+						!ChallengePlaysStore::<T>::contains_key(&challenge_id, &player),
+						Error::<T>::CannotPlayInNonParticipatingChallenge
+					);
+
+					T::Currency::reserve(&player, challenge_state.bet_amount)?;
+
+					let play_hash = challenge_play.generate_hash(challenger_secret);
+					ChallengePlaysStore::<T>::insert(&challenge_id, &player, play_hash);
+					Self::deposit_event(Event::PlayedInChallenge(challenge_id, player));
+
+					if ChallengePlaysStore::<T>::iter_key_prefix(&challenge_id).count() == 2 {
+						Self::deposit_event(Event::ChallengeReadyForReveal(challenge_id));
+					}
+
+					Ok(())
+				} else {
+					Err(Error::<T>::ChallengeStateForbidsPlay.into())
+				}
+			} else {
+				Err(Error::<T>::ChallengeNotFound.into())
+			}
+		}
+
+		// reveal
+		// - Challenger Id
+		// - Challenger Payload (HandType, Secret)
+		#[pallet::weight(10_000)]
+		pub fn reveal_challenge_results(
+			origin: OriginFor<T>,
+			origin_hand: ChallengePlay,
+			origin_secret: u64,
+			rival_hand: ChallengePlay,
+			rival_secret: u64,
+			challenge_id: ChallengeId,
+		) -> DispatchResult {
+			let player = ensure_signed(origin)?;
+
+			if let Err(e) = ChallengeStore::<T>::try_mutate(&challenge_id, |challenge_entry| {
+				if let Some(challenge) = challenge_entry {
+					if let ChallengeState::Accepted(ref challenge_state) = challenge {
+						ensure!(
+							challenge_state.contains_player(&player),
+							Error::<T>::CannotPlayInNonParticipatingChallenge
+						);
+
+						let player_hand_hash = Self::get_player_hand_hash(
+							&challenge_id,
+							&player,
+							Error::<T>::ChallengeStateForbidsResolution,
+						)?;
+
+						ensure!(
+							origin_hand.compare_hash_with(origin_secret, player_hand_hash),
+							Error::<T>::InvalidHandHash
+						);
+
+						let rival_player =
+							challenge_state.get_rival(&player).ok_or(Error::<T>::InvalidState)?;
+						let rival_hand_hash = Self::get_player_hand_hash(
+							&challenge_id,
+							&rival_player,
+							Error::<T>::ChallengeStateForbidsResolution,
+						)?;
+						ensure!(
+							rival_hand.compare_hash_with(rival_secret, rival_hand_hash),
+							Error::<T>::InvalidHandHash
+						);
+
+						let challenge_results = match origin_hand.beats(&rival_hand) {
+							PlayResult::Win => Some((&player, &rival_player)),
+							PlayResult::Lose => Some((&rival_player, &player)),
+							PlayResult::Draw => None,
+						};
+
+						if let Some((winner, loser)) = challenge_results {
+							T::Currency::repatriate_reserved(
+								loser,
+								&winner,
+								challenge_state.bet_amount,
+								BalanceStatus::Reserved,
+							)?;
+							T::Currency::unreserve(
+								winner,
+								challenge_state.bet_amount.mul(2_u32.into()),
+							);
+
+							*challenge_entry =
+								Some(ChallengeState::Finished(FinishedChallenge::from_accepted(
+									challenge_state.clone(),
+									Some(winner.clone()),
+								)));
+
+							Self::deposit_event(Event::ChallengeFinished(Some(winner.clone())));
+
+							Ok(())
+						} else {
+							T::Currency::unreserve(&player, challenge_state.bet_amount);
+							T::Currency::unreserve(&rival_player, challenge_state.bet_amount);
+
+							*challenge_entry = Some(ChallengeState::Finished(
+								FinishedChallenge::from_accepted(challenge_state.clone(), None),
+							));
+
+							Self::deposit_event(Event::ChallengeFinished(None));
+
+							Ok(())
+						}
+					} else {
+						Err(Error::<T>::ChallengeStateForbidsPlay.into())
+					}
+				} else {
+					Err(Error::<T>::ChallengeNotFound.into())
+				}
+			}) {
+				Err(e)
+			} else {
+				Ok(().into())
+			}
+		}
+	}
+
+	// Internal functions of the pallet
+	impl<T: Config> Pallet<T> {
+		fn get_player_hand_hash(
+			challenge_id: &ChallengeId,
+			player_id: &T::AccountId,
+			on_error: Error<T>,
+		) -> Result<ChallengePlayHash, Error<T>> {
+			if let Some(player_hand) = ChallengePlaysStore::<T>::get(&challenge_id, &player_id) {
+				Ok(player_hand)
+			} else {
+				Err(on_error)
+			}
+		}
+	}
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -7,16 +7,16 @@
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 use pallet_grandpa::{
-    fg_primitives, AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList,
+	fg_primitives, AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList,
 };
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
 use sp_runtime::{
-    create_runtime_str, generic, impl_opaque_keys,
-    traits::{AccountIdLookup, BlakeTwo256, Block as BlockT, IdentifyAccount, NumberFor, Verify},
-    transaction_validity::{TransactionSource, TransactionValidity},
-    ApplyExtrinsicResult, MultiSignature,
+	create_runtime_str, generic, impl_opaque_keys,
+	traits::{AccountIdLookup, BlakeTwo256, Block as BlockT, IdentifyAccount, NumberFor, Verify},
+	transaction_validity::{TransactionSource, TransactionValidity},
+	ApplyExtrinsicResult, MultiSignature,
 };
 use sp_std::prelude::*;
 #[cfg(feature = "std")]
@@ -25,13 +25,13 @@ use sp_version::RuntimeVersion;
 
 // A few exports that help ease life for downstream crates.
 pub use frame_support::{
-    construct_runtime, parameter_types,
-    traits::{ConstU128, ConstU32, ConstU8, KeyOwnerProofSystem, Randomness, StorageInfo},
-    weights::{
-        constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
-        IdentityFee, Weight,
-    },
-    StorageValue,
+	construct_runtime, parameter_types,
+	traits::{ConstU128, ConstU32, ConstU8, KeyOwnerProofSystem, Randomness, StorageInfo},
+	weights::{
+		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
+		IdentityFee, Weight,
+	},
+	StorageValue,
 };
 pub use pallet_balances::Call as BalancesCall;
 pub use pallet_timestamp::Call as TimestampCall;
@@ -67,42 +67,42 @@ pub type Hash = sp_core::H256;
 /// of data like extrinsics, allowing for them to continue syncing the network through upgrades
 /// to even the core data structures.
 pub mod opaque {
-    use super::*;
+	use super::*;
 
-    pub use sp_runtime::OpaqueExtrinsic as UncheckedExtrinsic;
+	pub use sp_runtime::OpaqueExtrinsic as UncheckedExtrinsic;
 
-    /// Opaque block header type.
-    pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
-    /// Opaque block type.
-    pub type Block = generic::Block<Header, UncheckedExtrinsic>;
-    /// Opaque block identifier type.
-    pub type BlockId = generic::BlockId<Block>;
+	/// Opaque block header type.
+	pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
+	/// Opaque block type.
+	pub type Block = generic::Block<Header, UncheckedExtrinsic>;
+	/// Opaque block identifier type.
+	pub type BlockId = generic::BlockId<Block>;
 
-    impl_opaque_keys! {
-        pub struct SessionKeys {
-            pub aura: Aura,
-            pub grandpa: Grandpa,
-        }
-    }
+	impl_opaque_keys! {
+		pub struct SessionKeys {
+			pub aura: Aura,
+			pub grandpa: Grandpa,
+		}
+	}
 }
 
 // To learn more about runtime versioning and what each of the following value means:
 //   https://docs.substrate.io/v3/runtime/upgrades#runtime-versioning
 #[sp_version::runtime_version]
 pub const VERSION: RuntimeVersion = RuntimeVersion {
-    spec_name: create_runtime_str!("node-rps"),
-    impl_name: create_runtime_str!("node-rps"),
-    authoring_version: 1,
-    // The version of the runtime specification. A full node will not attempt to use its native
-    //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
-    //   `spec_version`, and `authoring_version` are the same between Wasm and native.
-    // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
-    //   the compatible custom types.
-    spec_version: 100,
-    impl_version: 1,
-    apis: RUNTIME_API_VERSIONS,
-    transaction_version: 1,
-    state_version: 1,
+	spec_name: create_runtime_str!("node-rps"),
+	impl_name: create_runtime_str!("node-rps"),
+	authoring_version: 1,
+	// The version of the runtime specification. A full node will not attempt to use its native
+	//   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
+	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
+	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
+	//   the compatible custom types.
+	spec_version: 100,
+	impl_version: 1,
+	apis: RUNTIME_API_VERSIONS,
+	transaction_version: 1,
+	state_version: 1,
 };
 
 /// This determines the average expected block time that we are targeting.
@@ -125,170 +125,176 @@ pub const DAYS: BlockNumber = HOURS * 24;
 /// The version information used to identify this runtime when compiled natively.
 #[cfg(feature = "std")]
 pub fn native_version() -> NativeVersion {
-    NativeVersion { runtime_version: VERSION, can_author_with: Default::default() }
+	NativeVersion { runtime_version: VERSION, can_author_with: Default::default() }
 }
 
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 
 parameter_types! {
-    pub const Version: RuntimeVersion = VERSION;
-    pub const BlockHashCount: BlockNumber = 2400;
-    /// We allow for 2 seconds of compute with a 6 second average block time.
-    pub BlockWeights: frame_system::limits::BlockWeights = frame_system::limits::BlockWeights
-        ::with_sensible_defaults(2 * WEIGHT_PER_SECOND, NORMAL_DISPATCH_RATIO);
-    pub BlockLength: frame_system::limits::BlockLength = frame_system::limits::BlockLength
-        ::max_with_normal_ratio(5 * 1024 * 1024, NORMAL_DISPATCH_RATIO);
-    pub const SS58Prefix: u8 = 42;
+	pub const Version: RuntimeVersion = VERSION;
+	pub const BlockHashCount: BlockNumber = 2400;
+	/// We allow for 2 seconds of compute with a 6 second average block time.
+	pub BlockWeights: frame_system::limits::BlockWeights = frame_system::limits::BlockWeights
+		::with_sensible_defaults(2 * WEIGHT_PER_SECOND, NORMAL_DISPATCH_RATIO);
+	pub BlockLength: frame_system::limits::BlockLength = frame_system::limits::BlockLength
+		::max_with_normal_ratio(5 * 1024 * 1024, NORMAL_DISPATCH_RATIO);
+	pub const SS58Prefix: u8 = 42;
 }
 
 // Configure FRAME pallets to include in runtime.
 
 impl frame_system::Config for Runtime {
-    /// The basic call filter to use in dispatchable.
-    type BaseCallFilter = frame_support::traits::Everything;
-    /// Block & extrinsics weights: base values and limits.
-    type BlockWeights = BlockWeights;
-    /// The maximum length of a block (in bytes).
-    type BlockLength = BlockLength;
-    /// The identifier used to distinguish between accounts.
-    type AccountId = AccountId;
-    /// The aggregated dispatch type that is available for extrinsics.
-    type Call = Call;
-    /// The lookup mechanism to get account ID from whatever is passed in dispatchers.
-    type Lookup = AccountIdLookup<AccountId, ()>;
-    /// The index type for storing how many extrinsics an account has signed.
-    type Index = Index;
-    /// The index type for blocks.
-    type BlockNumber = BlockNumber;
-    /// The type for hashing blocks and tries.
-    type Hash = Hash;
-    /// The hashing algorithm used.
-    type Hashing = BlakeTwo256;
-    /// The header type.
-    type Header = generic::Header<BlockNumber, BlakeTwo256>;
-    /// The ubiquitous event type.
-    type Event = Event;
-    /// The ubiquitous origin type.
-    type Origin = Origin;
-    /// Maximum number of block number to block hash mappings to keep (oldest pruned first).
-    type BlockHashCount = BlockHashCount;
-    /// The weight of database operations that the runtime can invoke.
-    type DbWeight = RocksDbWeight;
-    /// Version of the runtime.
-    type Version = Version;
-    /// Converts a module to the index of the module in `construct_runtime!`.
-    ///
-    /// This type is being generated by `construct_runtime!`.
-    type PalletInfo = PalletInfo;
-    /// What to do if a new account is created.
-    type OnNewAccount = ();
-    /// What to do if an account is fully reaped from the system.
-    type OnKilledAccount = ();
-    /// The data to be stored in an account.
-    type AccountData = pallet_balances::AccountData<Balance>;
-    /// Weight information for the extrinsics of this pallet.
-    type SystemWeightInfo = ();
-    /// This is used as an identifier of the chain. 42 is the generic substrate prefix.
-    type SS58Prefix = SS58Prefix;
-    /// The set code logic, just the default since we're not a parachain.
-    type OnSetCode = ();
-    type MaxConsumers = frame_support::traits::ConstU32<16>;
+	/// The basic call filter to use in dispatchable.
+	type BaseCallFilter = frame_support::traits::Everything;
+	/// Block & extrinsics weights: base values and limits.
+	type BlockWeights = BlockWeights;
+	/// The maximum length of a block (in bytes).
+	type BlockLength = BlockLength;
+	/// The identifier used to distinguish between accounts.
+	type AccountId = AccountId;
+	/// The aggregated dispatch type that is available for extrinsics.
+	type Call = Call;
+	/// The lookup mechanism to get account ID from whatever is passed in dispatchers.
+	type Lookup = AccountIdLookup<AccountId, ()>;
+	/// The index type for storing how many extrinsics an account has signed.
+	type Index = Index;
+	/// The index type for blocks.
+	type BlockNumber = BlockNumber;
+	/// The type for hashing blocks and tries.
+	type Hash = Hash;
+	/// The hashing algorithm used.
+	type Hashing = BlakeTwo256;
+	/// The header type.
+	type Header = generic::Header<BlockNumber, BlakeTwo256>;
+	/// The ubiquitous event type.
+	type Event = Event;
+	/// The ubiquitous origin type.
+	type Origin = Origin;
+	/// Maximum number of block number to block hash mappings to keep (oldest pruned first).
+	type BlockHashCount = BlockHashCount;
+	/// The weight of database operations that the runtime can invoke.
+	type DbWeight = RocksDbWeight;
+	/// Version of the runtime.
+	type Version = Version;
+	/// Converts a module to the index of the module in `construct_runtime!`.
+	///
+	/// This type is being generated by `construct_runtime!`.
+	type PalletInfo = PalletInfo;
+	/// What to do if a new account is created.
+	type OnNewAccount = ();
+	/// What to do if an account is fully reaped from the system.
+	type OnKilledAccount = ();
+	/// The data to be stored in an account.
+	type AccountData = pallet_balances::AccountData<Balance>;
+	/// Weight information for the extrinsics of this pallet.
+	type SystemWeightInfo = ();
+	/// This is used as an identifier of the chain. 42 is the generic substrate prefix.
+	type SS58Prefix = SS58Prefix;
+	/// The set code logic, just the default since we're not a parachain.
+	type OnSetCode = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
 }
 
 impl pallet_randomness_collective_flip::Config for Runtime {}
 
 impl pallet_aura::Config for Runtime {
-    type AuthorityId = AuraId;
-    type DisabledValidators = ();
-    type MaxAuthorities = ConstU32<32>;
+	type AuthorityId = AuraId;
+	type DisabledValidators = ();
+	type MaxAuthorities = ConstU32<32>;
 }
 
 impl pallet_grandpa::Config for Runtime {
-    type Event = Event;
-    type Call = Call;
+	type Event = Event;
+	type Call = Call;
 
-    type KeyOwnerProofSystem = ();
+	type KeyOwnerProofSystem = ();
 
-    type KeyOwnerProof =
-    <Self::KeyOwnerProofSystem as KeyOwnerProofSystem<(KeyTypeId, GrandpaId)>>::Proof;
+	type KeyOwnerProof =
+		<Self::KeyOwnerProofSystem as KeyOwnerProofSystem<(KeyTypeId, GrandpaId)>>::Proof;
 
-    type KeyOwnerIdentification = <Self::KeyOwnerProofSystem as KeyOwnerProofSystem<(
-        KeyTypeId,
-        GrandpaId,
-    )>>::IdentificationTuple;
+	type KeyOwnerIdentification = <Self::KeyOwnerProofSystem as KeyOwnerProofSystem<(
+		KeyTypeId,
+		GrandpaId,
+	)>>::IdentificationTuple;
 
-    type HandleEquivocation = ();
+	type HandleEquivocation = ();
 
-    type WeightInfo = ();
-    type MaxAuthorities = ConstU32<32>;
+	type WeightInfo = ();
+	type MaxAuthorities = ConstU32<32>;
 }
 
 parameter_types! {
-    pub const MinimumPeriod: u64 = SLOT_DURATION / 2;
+	pub const MinimumPeriod: u64 = SLOT_DURATION / 2;
 }
 
 impl pallet_timestamp::Config for Runtime {
-    /// A timestamp: milliseconds since the unix epoch.
-    type Moment = u64;
-    type OnTimestampSet = Aura;
-    type MinimumPeriod = MinimumPeriod;
-    type WeightInfo = ();
+	/// A timestamp: milliseconds since the unix epoch.
+	type Moment = u64;
+	type OnTimestampSet = Aura;
+	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = ();
 }
 
 impl pallet_balances::Config for Runtime {
-    type MaxLocks = ConstU32<50>;
-    type MaxReserves = ();
-    type ReserveIdentifier = [u8; 8];
-    /// The type for recording an account's balance.
-    type Balance = Balance;
-    /// The ubiquitous event type.
-    type Event = Event;
-    type DustRemoval = ();
-    type ExistentialDeposit = ConstU128<500>;
-    type AccountStore = System;
-    type WeightInfo = pallet_balances::weights::SubstrateWeight<Runtime>;
+	type MaxLocks = ConstU32<50>;
+	type MaxReserves = ();
+	type ReserveIdentifier = [u8; 8];
+	/// The type for recording an account's balance.
+	type Balance = Balance;
+	/// The ubiquitous event type.
+	type Event = Event;
+	type DustRemoval = ();
+	type ExistentialDeposit = ConstU128<500>;
+	type AccountStore = System;
+	type WeightInfo = pallet_balances::weights::SubstrateWeight<Runtime>;
 }
 
 parameter_types! {
-    pub const TransactionByteFee: Balance = 1;
+	pub const TransactionByteFee: Balance = 1;
 }
 
 impl pallet_transaction_payment::Config for Runtime {
-    type OnChargeTransaction = CurrencyAdapter<Balances, ()>;
-    type TransactionByteFee = TransactionByteFee;
-    type OperationalFeeMultiplier = ConstU8<5>;
-    type WeightToFee = IdentityFee<Balance>;
-    type FeeMultiplierUpdate = ();
+	type OnChargeTransaction = CurrencyAdapter<Balances, ()>;
+	type TransactionByteFee = TransactionByteFee;
+	type OperationalFeeMultiplier = ConstU8<5>;
+	type WeightToFee = IdentityFee<Balance>;
+	type FeeMultiplierUpdate = ();
 }
 
 impl pallet_sudo::Config for Runtime {
-    type Event = Event;
-    type Call = Call;
+	type Event = Event;
+	type Call = Call;
+}
+
+parameter_types! {
+	pub const MinBetAmount: u64 = 100;
 }
 
 /// Configure the pallet-rps in pallets/rps.
 impl pallet_rps::Config for Runtime {
-    type Event = Event;
+	type Event = Event;
+	type Currency = Balances;
+	type MinBetAmount = MinBetAmount;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.
 construct_runtime!(
-    pub enum Runtime where
-        Block = Block,
-        NodeBlock = opaque::Block,
-        UncheckedExtrinsic = UncheckedExtrinsic
-    {
-        System: frame_system,
-        RandomnessCollectiveFlip: pallet_randomness_collective_flip,
-        Timestamp: pallet_timestamp,
-        Aura: pallet_aura,
-        Grandpa: pallet_grandpa,
-        Balances: pallet_balances,
-        TransactionPayment: pallet_transaction_payment,
-        Sudo: pallet_sudo,
-        // Include the custom logic from the pallet-template in the runtime.
-        RpsModule: pallet_rps,
-    }
+	pub enum Runtime where
+		Block = Block,
+		NodeBlock = opaque::Block,
+		UncheckedExtrinsic = UncheckedExtrinsic
+	{
+		System: frame_system,
+		RandomnessCollectiveFlip: pallet_randomness_collective_flip,
+		Timestamp: pallet_timestamp,
+		Aura: pallet_aura,
+		Grandpa: pallet_grandpa,
+		Balances: pallet_balances,
+		TransactionPayment: pallet_transaction_payment,
+		Sudo: pallet_sudo,
+		// Include the custom logic from the pallet-template in the runtime.
+		RpsModule: pallet_rps,
+	}
 );
 
 /// The address format for describing accounts.
@@ -299,24 +305,24 @@ pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 pub type Block = generic::Block<Header, UncheckedExtrinsic>;
 /// The SignedExtension to the basic transaction logic.
 pub type SignedExtra = (
-    frame_system::CheckNonZeroSender<Runtime>,
-    frame_system::CheckSpecVersion<Runtime>,
-    frame_system::CheckTxVersion<Runtime>,
-    frame_system::CheckGenesis<Runtime>,
-    frame_system::CheckEra<Runtime>,
-    frame_system::CheckNonce<Runtime>,
-    frame_system::CheckWeight<Runtime>,
-    pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+	frame_system::CheckNonZeroSender<Runtime>,
+	frame_system::CheckSpecVersion<Runtime>,
+	frame_system::CheckTxVersion<Runtime>,
+	frame_system::CheckGenesis<Runtime>,
+	frame_system::CheckEra<Runtime>,
+	frame_system::CheckNonce<Runtime>,
+	frame_system::CheckWeight<Runtime>,
+	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, Call, Signature, SignedExtra>;
 /// Executive: handles dispatch to the various modules.
 pub type Executive = frame_executive::Executive<
-    Runtime,
-    Block,
-    frame_system::ChainContext<Runtime>,
-    Runtime,
-    AllPalletsWithSystem,
+	Runtime,
+	Block,
+	frame_system::ChainContext<Runtime>,
+	Runtime,
+	AllPalletsWithSystem,
 >;
 
 #[cfg(feature = "runtime-benchmarks")]
@@ -325,194 +331,194 @@ extern crate frame_benchmarking;
 
 #[cfg(feature = "runtime-benchmarks")]
 mod benches {
-    define_benchmarks!(
-        [frame_benchmarking, BaselineBench::<Runtime>]
-        [frame_system, SystemBench::<Runtime>]
-        [pallet_balances, Balances]
-        [pallet_timestamp, Timestamp]
-        [pallet_rps, RpsModule]
-    );
+	define_benchmarks!(
+		[frame_benchmarking, BaselineBench::<Runtime>]
+		[frame_system, SystemBench::<Runtime>]
+		[pallet_balances, Balances]
+		[pallet_timestamp, Timestamp]
+		[pallet_rps, RpsModule]
+	);
 }
 
 impl_runtime_apis! {
-    impl sp_api::Core<Block> for Runtime {
-        fn version() -> RuntimeVersion {
-            VERSION
-        }
+	impl sp_api::Core<Block> for Runtime {
+		fn version() -> RuntimeVersion {
+			VERSION
+		}
 
-        fn execute_block(block: Block) {
-            Executive::execute_block(block);
-        }
+		fn execute_block(block: Block) {
+			Executive::execute_block(block);
+		}
 
-        fn initialize_block(header: &<Block as BlockT>::Header) {
-            Executive::initialize_block(header)
-        }
-    }
+		fn initialize_block(header: &<Block as BlockT>::Header) {
+			Executive::initialize_block(header)
+		}
+	}
 
-    impl sp_api::Metadata<Block> for Runtime {
-        fn metadata() -> OpaqueMetadata {
-            OpaqueMetadata::new(Runtime::metadata().into())
-        }
-    }
+	impl sp_api::Metadata<Block> for Runtime {
+		fn metadata() -> OpaqueMetadata {
+			OpaqueMetadata::new(Runtime::metadata().into())
+		}
+	}
 
-    impl sp_block_builder::BlockBuilder<Block> for Runtime {
-        fn apply_extrinsic(extrinsic: <Block as BlockT>::Extrinsic) -> ApplyExtrinsicResult {
-            Executive::apply_extrinsic(extrinsic)
-        }
+	impl sp_block_builder::BlockBuilder<Block> for Runtime {
+		fn apply_extrinsic(extrinsic: <Block as BlockT>::Extrinsic) -> ApplyExtrinsicResult {
+			Executive::apply_extrinsic(extrinsic)
+		}
 
-        fn finalize_block() -> <Block as BlockT>::Header {
-            Executive::finalize_block()
-        }
+		fn finalize_block() -> <Block as BlockT>::Header {
+			Executive::finalize_block()
+		}
 
-        fn inherent_extrinsics(data: sp_inherents::InherentData) -> Vec<<Block as BlockT>::Extrinsic> {
-            data.create_extrinsics()
-        }
+		fn inherent_extrinsics(data: sp_inherents::InherentData) -> Vec<<Block as BlockT>::Extrinsic> {
+			data.create_extrinsics()
+		}
 
-        fn check_inherents(
-            block: Block,
-            data: sp_inherents::InherentData,
-        ) -> sp_inherents::CheckInherentsResult {
-            data.check_extrinsics(&block)
-        }
-    }
+		fn check_inherents(
+			block: Block,
+			data: sp_inherents::InherentData,
+		) -> sp_inherents::CheckInherentsResult {
+			data.check_extrinsics(&block)
+		}
+	}
 
-    impl sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block> for Runtime {
-        fn validate_transaction(
-            source: TransactionSource,
-            tx: <Block as BlockT>::Extrinsic,
-            block_hash: <Block as BlockT>::Hash,
-        ) -> TransactionValidity {
-            Executive::validate_transaction(source, tx, block_hash)
-        }
-    }
+	impl sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block> for Runtime {
+		fn validate_transaction(
+			source: TransactionSource,
+			tx: <Block as BlockT>::Extrinsic,
+			block_hash: <Block as BlockT>::Hash,
+		) -> TransactionValidity {
+			Executive::validate_transaction(source, tx, block_hash)
+		}
+	}
 
-    impl sp_offchain::OffchainWorkerApi<Block> for Runtime {
-        fn offchain_worker(header: &<Block as BlockT>::Header) {
-            Executive::offchain_worker(header)
-        }
-    }
+	impl sp_offchain::OffchainWorkerApi<Block> for Runtime {
+		fn offchain_worker(header: &<Block as BlockT>::Header) {
+			Executive::offchain_worker(header)
+		}
+	}
 
-    impl sp_consensus_aura::AuraApi<Block, AuraId> for Runtime {
-        fn slot_duration() -> sp_consensus_aura::SlotDuration {
-            sp_consensus_aura::SlotDuration::from_millis(Aura::slot_duration())
-        }
+	impl sp_consensus_aura::AuraApi<Block, AuraId> for Runtime {
+		fn slot_duration() -> sp_consensus_aura::SlotDuration {
+			sp_consensus_aura::SlotDuration::from_millis(Aura::slot_duration())
+		}
 
-        fn authorities() -> Vec<AuraId> {
-            Aura::authorities().into_inner()
-        }
-    }
+		fn authorities() -> Vec<AuraId> {
+			Aura::authorities().into_inner()
+		}
+	}
 
-    impl sp_session::SessionKeys<Block> for Runtime {
-        fn generate_session_keys(seed: Option<Vec<u8>>) -> Vec<u8> {
-            opaque::SessionKeys::generate(seed)
-        }
+	impl sp_session::SessionKeys<Block> for Runtime {
+		fn generate_session_keys(seed: Option<Vec<u8>>) -> Vec<u8> {
+			opaque::SessionKeys::generate(seed)
+		}
 
-        fn decode_session_keys(
-            encoded: Vec<u8>,
-        ) -> Option<Vec<(Vec<u8>, KeyTypeId)>> {
-            opaque::SessionKeys::decode_into_raw_public_keys(&encoded)
-        }
-    }
+		fn decode_session_keys(
+			encoded: Vec<u8>,
+		) -> Option<Vec<(Vec<u8>, KeyTypeId)>> {
+			opaque::SessionKeys::decode_into_raw_public_keys(&encoded)
+		}
+	}
 
-    impl fg_primitives::GrandpaApi<Block> for Runtime {
-        fn grandpa_authorities() -> GrandpaAuthorityList {
-            Grandpa::grandpa_authorities()
-        }
+	impl fg_primitives::GrandpaApi<Block> for Runtime {
+		fn grandpa_authorities() -> GrandpaAuthorityList {
+			Grandpa::grandpa_authorities()
+		}
 
-        fn current_set_id() -> fg_primitives::SetId {
-            Grandpa::current_set_id()
-        }
+		fn current_set_id() -> fg_primitives::SetId {
+			Grandpa::current_set_id()
+		}
 
-        fn submit_report_equivocation_unsigned_extrinsic(
-            _equivocation_proof: fg_primitives::EquivocationProof<
-                <Block as BlockT>::Hash,
-                NumberFor<Block>,
-            >,
-            _key_owner_proof: fg_primitives::OpaqueKeyOwnershipProof,
-        ) -> Option<()> {
-            None
-        }
+		fn submit_report_equivocation_unsigned_extrinsic(
+			_equivocation_proof: fg_primitives::EquivocationProof<
+				<Block as BlockT>::Hash,
+				NumberFor<Block>,
+			>,
+			_key_owner_proof: fg_primitives::OpaqueKeyOwnershipProof,
+		) -> Option<()> {
+			None
+		}
 
-        fn generate_key_ownership_proof(
-            _set_id: fg_primitives::SetId,
-            _authority_id: GrandpaId,
-        ) -> Option<fg_primitives::OpaqueKeyOwnershipProof> {
-            // NOTE: this is the only implementation possible since we've
-            // defined our key owner proof type as a bottom type (i.e. a type
-            // with no values).
-            None
-        }
-    }
+		fn generate_key_ownership_proof(
+			_set_id: fg_primitives::SetId,
+			_authority_id: GrandpaId,
+		) -> Option<fg_primitives::OpaqueKeyOwnershipProof> {
+			// NOTE: this is the only implementation possible since we've
+			// defined our key owner proof type as a bottom type (i.e. a type
+			// with no values).
+			None
+		}
+	}
 
-    impl frame_system_rpc_runtime_api::AccountNonceApi<Block, AccountId, Index> for Runtime {
-        fn account_nonce(account: AccountId) -> Index {
-            System::account_nonce(account)
-        }
-    }
+	impl frame_system_rpc_runtime_api::AccountNonceApi<Block, AccountId, Index> for Runtime {
+		fn account_nonce(account: AccountId) -> Index {
+			System::account_nonce(account)
+		}
+	}
 
-    impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<Block, Balance> for Runtime {
-        fn query_info(
-            uxt: <Block as BlockT>::Extrinsic,
-            len: u32,
-        ) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
-            TransactionPayment::query_info(uxt, len)
-        }
-        fn query_fee_details(
-            uxt: <Block as BlockT>::Extrinsic,
-            len: u32,
-        ) -> pallet_transaction_payment::FeeDetails<Balance> {
-            TransactionPayment::query_fee_details(uxt, len)
-        }
-    }
+	impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentApi<Block, Balance> for Runtime {
+		fn query_info(
+			uxt: <Block as BlockT>::Extrinsic,
+			len: u32,
+		) -> pallet_transaction_payment_rpc_runtime_api::RuntimeDispatchInfo<Balance> {
+			TransactionPayment::query_info(uxt, len)
+		}
+		fn query_fee_details(
+			uxt: <Block as BlockT>::Extrinsic,
+			len: u32,
+		) -> pallet_transaction_payment::FeeDetails<Balance> {
+			TransactionPayment::query_fee_details(uxt, len)
+		}
+	}
 
-    #[cfg(feature = "runtime-benchmarks")]
-    impl frame_benchmarking::Benchmark<Block> for Runtime {
-        fn benchmark_metadata(extra: bool) -> (
-            Vec<frame_benchmarking::BenchmarkList>,
-            Vec<frame_support::traits::StorageInfo>,
-        ) {
-            use frame_benchmarking::{baseline, Benchmarking, BenchmarkList};
-            use frame_support::traits::StorageInfoTrait;
-            use frame_system_benchmarking::Pallet as SystemBench;
-            use baseline::Pallet as BaselineBench;
+	#[cfg(feature = "runtime-benchmarks")]
+	impl frame_benchmarking::Benchmark<Block> for Runtime {
+		fn benchmark_metadata(extra: bool) -> (
+			Vec<frame_benchmarking::BenchmarkList>,
+			Vec<frame_support::traits::StorageInfo>,
+		) {
+			use frame_benchmarking::{baseline, Benchmarking, BenchmarkList};
+			use frame_support::traits::StorageInfoTrait;
+			use frame_system_benchmarking::Pallet as SystemBench;
+			use baseline::Pallet as BaselineBench;
 
-            let mut list = Vec::<BenchmarkList>::new();
-            list_benchmarks!(list, extra);
+			let mut list = Vec::<BenchmarkList>::new();
+			list_benchmarks!(list, extra);
 
-            let storage_info = AllPalletsWithSystem::storage_info();
+			let storage_info = AllPalletsWithSystem::storage_info();
 
-            return (list, storage_info)
-        }
+			return (list, storage_info)
+		}
 
-        fn dispatch_benchmark(
-            config: frame_benchmarking::BenchmarkConfig
-        ) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, sp_runtime::RuntimeString> {
-            use frame_benchmarking::{baseline, Benchmarking, BenchmarkBatch, TrackedStorageKey};
+		fn dispatch_benchmark(
+			config: frame_benchmarking::BenchmarkConfig
+		) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, sp_runtime::RuntimeString> {
+			use frame_benchmarking::{baseline, Benchmarking, BenchmarkBatch, TrackedStorageKey};
 
-            use frame_system_benchmarking::Pallet as SystemBench;
-            use baseline::Pallet as BaselineBench;
+			use frame_system_benchmarking::Pallet as SystemBench;
+			use baseline::Pallet as BaselineBench;
 
-            impl frame_system_benchmarking::Config for Runtime {}
-            impl baseline::Config for Runtime {}
+			impl frame_system_benchmarking::Config for Runtime {}
+			impl baseline::Config for Runtime {}
 
-            let whitelist: Vec<TrackedStorageKey> = vec![
-                // Block Number
-                hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac").to_vec().into(),
-                // Total Issuance
-                hex_literal::hex!("c2261276cc9d1f8598ea4b6a74b15c2f57c875e4cff74148e4628f264b974c80").to_vec().into(),
-                // Execution Phase
-                hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef7ff553b5a9862a516939d82b3d3d8661a").to_vec().into(),
-                // Event Count
-                hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef70a98fdbe9ce6c55837576c60c7af3850").to_vec().into(),
-                // System Events
-                hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef780d41e5e16056765bc8461851072c9d7").to_vec().into(),
-            ];
+			let whitelist: Vec<TrackedStorageKey> = vec![
+				// Block Number
+				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac").to_vec().into(),
+				// Total Issuance
+				hex_literal::hex!("c2261276cc9d1f8598ea4b6a74b15c2f57c875e4cff74148e4628f264b974c80").to_vec().into(),
+				// Execution Phase
+				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef7ff553b5a9862a516939d82b3d3d8661a").to_vec().into(),
+				// Event Count
+				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef70a98fdbe9ce6c55837576c60c7af3850").to_vec().into(),
+				// System Events
+				hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef780d41e5e16056765bc8461851072c9d7").to_vec().into(),
+			];
 
-            let mut batches = Vec::<BenchmarkBatch>::new();
-            let params = (&config, &whitelist);
-            add_benchmarks!(params, batches);
+			let mut batches = Vec::<BenchmarkBatch>::new();
+			let params = (&config, &whitelist);
+			add_benchmarks!(params, batches);
 
-            Ok(batches)
-        }
-    }
+			Ok(batches)
+		}
+	}
 }


### PR DESCRIPTION
Implementation of a game of Rock-Paper-Scissors using the Substrate node [template](https://github.com/substrate-developer-hub/substrate-node-template)

The pallet has the following extrinsic methods:

* **create_challenge**: Allows an account to create a new RPS Challenge setting a bet amount to be payed to the winner. 
* **enter_challenge**: Allows another account to enter a created RPS Challenge
* **play_challenge**: Allows each of the challenge participants to play their hand (Rock, Paper or Scissors) the actual value is hashed with a secret so that the other user cannot guess what their opponent has played.
* **reveal_challenge_results**: Reveals the results of the challenge once both accounts have played their hands, this requires that both participants send both their hand and secret code in order to validate the originally stored hashes.

Additionally we have the following storage elements:

* **NextBetId**: Use to generate the next identifier when a bet is placed.
* **ChallengeStore**: A StoreMap used to hold the challenges
* **ChallengePlaysStore**: A StorageDoubleMap used to hold the different plays for all the challenges.

The code doesn't currently have neither tests nor benchmarks.

Most of the relevant code can be found in the `pallets/rps/src/lib.rs` file.